### PR TITLE
Sidebar logic + EntryList visual fix

### DIFF
--- a/src/components/AnimatedHamburger.svelte
+++ b/src/components/AnimatedHamburger.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
-	export let open = false;
-	export let onClickHambuger = (): void => {
-		open = !open;
-	};
+	let open = false;
+
+	import { toggleLeftSidebar } from '$src/stores/store';
 
 	export let ariaLabel = 'toggle menu';
 	export let width: string | number = 45;
 </script>
 
-<button on:click={onClickHambuger} aria-expanded={open} aria-label={ariaLabel}>
+<button
+	on:click={() => {
+		toggleLeftSidebar.update((n) => !n);
+		open = !open;
+	}}
+	aria-expanded={open}
+	aria-label={ariaLabel}
+>
 	<svg class:open viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="5" {width}>
 		<path
 			class="top"

--- a/src/components/EntryList.svelte
+++ b/src/components/EntryList.svelte
@@ -17,12 +17,6 @@
 	export let category = 'Some';
 	export let fields: any;
 
-	export let toggleLeftSideBar = true;
-	export let onClickHambuger = (): void => {
-		// open = !open;
-		toggleLeftSideBar = !toggleLeftSideBar;
-	};
-
 	// typesafe-i18n
 	import LL from '$i18n/i18n-svelte';
 
@@ -232,13 +226,10 @@
 
 <Modal />
 
-<div class="relative -mt-[65px] md:mt-0">
+<div class="relative md:mt-0">
 	<div class="mb-2 flex items-center gap-2">
 		{#if !switchSideBar}
-			<!-- mobile and tablet hamburger 
-			
-		--><AnimatedHamburger {onClickHambuger} />
-			<!-- <AnimatedHamburger on:click={onClickHamburger} /> -->
+			<AnimatedHamburger />
 		{/if}
 		<div class="flex flex-col">
 			{#if category}<div class="mb-2 text-xs capitalize text-surface-500 dark:text-surface-300">

--- a/src/routes/[[lang]]/+layout.svelte
+++ b/src/routes/[[lang]]/+layout.svelte
@@ -112,12 +112,12 @@
 	}
 	//shape_fields(collection.fields).then((data) => (fields = data));
 
-	export let toggleLeftSideBar = false;
-	//export let open = false;
-	export let onClickHambuger = (): void => {
-		// open = !open;
-		toggleLeftSideBar = !toggleLeftSideBar;
-	};
+	import { toggleLeftSidebar } from '$src/stores/store';
+
+	var leftSidebarOn: boolean;
+	toggleLeftSidebar.subscribe((n) => {
+		leftSidebarOn = n;
+	});
 
 	// show/hide Right Sidebar
 	let toggleRightSideBar = true;
@@ -150,7 +150,7 @@
 	slotSidebarLeft="!overflow-visible bg-white dark:bg-gradient-to-r dark:from-surface-800 dark:via-surface-700
 dark:to-surface-500 text-center h-full relative border-r !px-2 border-surface-300 flex flex-col items-center z-10 
 {switchSideBar ? 'w-[225px]' : 'w-[85px]'}
-{toggleLeftSideBar ? 'hidden' : 'block'}"
+{leftSidebarOn ? 'hidden' : 'block'}"
 	slotSidebarRight="bg-white border-l border-surface-300 dark:bg-gradient-to-r dark:from-surface-600 dark:via-surface-700 dark:to-surface-800 text-center px-1 h-full relative {toggleRightSideBar
 		? 'hidden'
 		: 'block'} "
@@ -168,8 +168,7 @@ dark:to-surface-500 text-center h-full relative border-r !px-2 border-surface-30
 				<strong class="text-xl uppercase">{PUBLIC_SITENAME}</strong>
 			</svelte:fragment>
 
-			<button on:click={() => (toggleLeftSideBar = !toggleLeftSideBar)} class="btn btn-base"
-				>SD-Left</button
+			<button on:click={() => (leftSidebarOn = !leftSidebarOn)} class="btn btn-base">SD-Left</button
 			>
 
 			<button
@@ -193,7 +192,7 @@ dark:to-surface-500 text-center h-full relative border-r !px-2 border-surface-30
 	<!-- Sidebar Left -->
 	<svelte:fragment slot="sidebarLeft">
 		{#if !switchSideBar}
-			<AnimatedHamburger {onClickHambuger} />
+			<AnimatedHamburger />
 		{/if}
 
 		<!-- Corporate Identity -->
@@ -281,7 +280,7 @@ dark:to-surface-500 text-center h-full relative border-r !px-2 border-surface-30
 
 			{#if switchSideBar}
 				<div
-					hidden={toggleLeftSideBar}
+					hidden={leftSidebarOn}
 					class="grid grid-cols-2 md:grid-cols-3 grid-rows-2 md:gap-2 items-center"
 				>
 					<div class="md:row-span-2">

--- a/src/routes/[[lang]]/+page.svelte
+++ b/src/routes/[[lang]]/+page.svelte
@@ -32,7 +32,6 @@
 
 {#if $showFieldsStore.showField}
 	<EntryList
-		bind:toggleSideBar
 		bind:deleteMode
 		{fields}
 		{collection}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -26,3 +26,6 @@ export const language: Writable<string> = writable(PUBLIC_LANGUAGE);
 
 // Store image data while editing
 export const saveEditedImage: Writable<boolean> = writable(false);
+
+// Store image data while editing
+export const toggleLeftSidebar: Writable<boolean> = writable(true);


### PR DESCRIPTION
Sidebar toggling is now done using stores (because it requires communication between layout.svelte and page.svelte so binding is not possible)

EntryList margin removed so it doesn't break on mobile.